### PR TITLE
Allows quit to exit the shell after all commands have been executed

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -175,7 +175,8 @@ bool runCommand(char strInput[], bool batchMode) {
 		if ( (strcmp(command, "quit") == 0) || (strcmp(command, "exit") == 0)) {
 			// Exits parent shell
 			exitStatus = false;
-			break;
+			command = strtok(NULL, ";");
+			continue;
 		}
 		else if ((strcmp(command, "help") == 0)) {
 			printf("/--------[ HELP: LIST OF INTERNAL COMMANDS ]-------\\\n"


### PR DESCRIPTION
Quit command does not have to be at the end of the command string

![screenshot](http://i.imgur.com/JoZEayw.png)
